### PR TITLE
support documentation and tags for enumeration literals

### DIFF
--- a/src/transport/enum.js
+++ b/src/transport/enum.js
@@ -38,9 +38,19 @@ function addEnumLiterals(enumObj, enume) {
     enumObj[fields.Enum] = enumArr;
     let literals = enume.literals;
     forEach(literals, function (literal) {
-
-        enumArr.push(literal.name);
-
+        let literalObj = {};
+        literalObj[fields.name] = literal.name;
+        literalObj[fields.description] = literal.documentation;
+        enumArr.push(literalObj);
+        let tagArr = [];
+        literalObj[fields.tags] = tagArr;
+        let tags = literal.tags;
+        forEach(tags, function (tag) {
+                let tagObj = {};
+                tagObj[fields.name] = tag.name;
+                tagObj[fields.value] = tag.value;
+                tagArr.push(tagObj);
+            });
     });
 }
 
@@ -98,10 +108,11 @@ function bindEnumAttributesToImport(enumeObject, mSubObject) {
     let literals = [];
     enumeObject.literals = literals;
 
-    forEach(mSubObject[fields.Enum], function (literal) {
+    forEach(mSubObject[fields.Enum], function (attr) {
         let objAttr = {};
         objAttr._type = 'UMLEnumerationLiteral';
-        objAttr.name = literal;
+        objAttr.name = attr.name;
+        objAttr.documentation = attr.description;
         literals.push(objAttr);
     });
 

--- a/src/transport/fields.js
+++ b/src/transport/fields.js
@@ -36,5 +36,7 @@ const fields = {
     'aggregation': 'aggregation',
     'composition': 'composition',
     'interface': 'interface',
+    'value': 'value',
+    'tags': 'tags',
 };
 module.exports = fields;

--- a/src/transport/utils.js
+++ b/src/transport/utils.js
@@ -227,8 +227,23 @@ function bindLiterals(attr) {
     /* UMLAttribute */
     let objAttr = {};
     objAttr._type = 'UMLEnumerationLiteral';
-    objAttr.name = attr;
-    return objAttr;
+    objAttr.name = attr.name;
+    objAttr.documentation = attr.description;
+    let tags = attr.tags;
+    let arrTags = [];
+    objAttr.tags = arrTags;
+    /* Tag */
+    forEach(tags, function (tag) {
+        let objTag = {};
+        objTag._type = 'Tag';
+        objTag.name = tag.name;
+        //TODO : Remove below comment and resolve issue
+        objTag.kind = 'string' //param.DataType.type;
+        objTag.value = tag.value;
+
+        arrTags.push(objTag);
+    });
+   return objAttr;
 }
 
 function bindProperty(attr) {


### PR DESCRIPTION
@faizanvahevaria please check it out and improve where it is needed. Basically I just needed to keep documentation and tags for enumeration literals, but tags needs to be supported for any kind of exportable entity - class, attribute etc.