### PR TITLE
use select instead of search for data types

### DIFF
--- a/src/transport/utils.js
+++ b/src/transport/utils.js
@@ -76,32 +76,32 @@ function addDatatype(propertyObj, attr) {
 function getDatatype(attr) {
     let dType = {};
     if (attr.type == fields.Entity) {
-        let res = app.repository.search(attr.name);
-        forEach(res, function (item) {
-            if (item instanceof type.UMLClass) {
-                dType['$ref'] = item._id;
-            }
-        });
+        let item = app.repository.select("@UMLClass[name="+ attr.name+ "]");
+        if(item === undefined){
+            console.error("Class for "+ attr.name+ " not found.")
+        } else{
+            dType['$ref'] = item._id;
+        }
         return dType;
 
     } else if (attr.type == fields.Event) {
-        let res = app.repository.search(attr.name);
-        forEach(res, function (item) {
-            if (item instanceof type.UMLInterface) {
-                dType['$ref'] = item._id;
-            }
-        });
+        let item = app.repository.select("@UMLInterface[name="+ attr.name+ "]");
+        if(item === undefined){
+            console.error("Class for "+ attr.name+ " not found.")
+        } else{
+            dType['$ref'] = item._id;
+        }
         return dType;
 
     } else if (attr.type == fields.Enum) {
-
-        let res = app.repository.search(attr.name);
-        forEach(res, function (item) {
-            if (item instanceof type.UMLEnumeration) {
-                dType['$ref'] = item._id;
-            }
-        });
+        let item = app.repository.select("@UMLEnumeration[name="+ attr.name+ "]");
+        if(item === undefined){
+            console.error("Class for "+ attr.name+ " not found.")
+        } else{
+            dType['$ref'] = item._id;
+        }
         return dType;
+
     } else if (isString(attr.type)) {
         return attr.type
     }

--- a/src/transport/utils.js
+++ b/src/transport/utils.js
@@ -77,28 +77,28 @@ function getDatatype(attr) {
     let dType = {};
     if (attr.type == fields.Entity) {
         let item = app.repository.select("@UMLClass[name="+ attr.name+ "]");
-        if(item === undefined){
+        if(item[0] === undefined){
             console.error("Class for "+ attr.name+ " not found.")
         } else{
-            dType['$ref'] = item._id;
+            dType['$ref'] = item[0]._id;
         }
         return dType;
 
     } else if (attr.type == fields.Event) {
         let item = app.repository.select("@UMLInterface[name="+ attr.name+ "]");
-        if(item === undefined){
+        if(item[0] === undefined){
             console.error("Class for "+ attr.name+ " not found.")
         } else{
-            dType['$ref'] = item._id;
+            dType['$ref'] = item[0]._id;
         }
         return dType;
 
     } else if (attr.type == fields.Enum) {
         let item = app.repository.select("@UMLEnumeration[name="+ attr.name+ "]");
-        if(item === undefined){
+        if(item[0] === undefined){
             console.error("Class for "+ attr.name+ " not found.")
         } else{
-            dType['$ref'] = item._id;
+            dType['$ref'] = item[0]._id;
         }
         return dType;
 


### PR DESCRIPTION
@faizanvahevaria , I had to update `getDatatype` function to make it working with the cases, when `app.repository.search` returns too many results, for example when an attr.name is `Code`, the number of matched items is about 8000. 
I think that we should use `app.repository.select` rather than `app.repository.search`, where it is possible. What do you think?